### PR TITLE
default to use SHA instead of tag

### DIFF
--- a/pkg/cmd/cli/cmd/translate_ist.go
+++ b/pkg/cmd/cli/cmd/translate_ist.go
@@ -97,7 +97,7 @@ $ obu translate nodejs:12 -n openshift
 	}
 	translateCmd.Flags().BoolVar(&(cfg.OverrideLocal), "override-local", cfg.OverrideLocal,
 		"Bypass local copy of image in OpenShift Internal registry and return external registry reference.")
-	translateCmd.Flags().BoolVar(&(cfg.SHA), "sha-vs-tag", cfg.SHA,
+	translateCmd.Flags().BoolVar(&(cfg.SHA), "sha-vs-tag", true,
 		"End the translated image reference with the SHA instead of the tag name.")
 	translateCmd.Flags().StringVarP(&(cfg.Namespace), "namespace", "n", "",
 		"Specify the namespace the image stream is located in")


### PR DESCRIPTION
:smile: That's the best you'll get from me for now though I suppose a "done right" is to make a `newCfg` func that comes with this out of the box.  

If this is going to always be used as a binary rather than an API I suppose it's no issue.